### PR TITLE
Dev/layout tinkering

### DIFF
--- a/src/analysis_page.py
+++ b/src/analysis_page.py
@@ -46,6 +46,10 @@ class AnalysisPage(QWidget):
         # right side
         layout.addWidget(self.move_notes, 0, 1, 2, 1)
         
+        # set size policy
+        layout.setColumnStretch(0,1)
+        layout.setColumnStretch(1,2)
+
         self.setLayout(layout)
 
     def _on_move_made(self, _):

--- a/src/analysis_page.py
+++ b/src/analysis_page.py
@@ -1,4 +1,4 @@
-from PySide2.QtWidgets import QWidget, QLabel, QGridLayout
+from PySide2.QtWidgets import QWidget, QLabel, QGridLayout, QScrollArea
 from PySide2.QtCore import Qt
 import hichess
 from chess import pgn
@@ -41,7 +41,11 @@ class AnalysisPage(QWidget):
 
         # left side
         layout.addWidget(self.sq_board_widget, 0, 0)
-        layout.addWidget(self.engine_evaluation, 1, 0)
+
+        scroll = QScrollArea()
+        scroll.setWidgetResizable(True)
+        scroll.setWidget(self.engine_evaluation)
+        layout.addWidget(scroll, 1, 0)
 
         # right side
         layout.addWidget(self.move_notes, 0, 1, 2, 1)

--- a/src/analysis_page.py
+++ b/src/analysis_page.py
@@ -65,4 +65,10 @@ class AnalysisPage(QWidget):
         # TODO send the new position to the engine
         self.engine_evaluation.evaluate(self.game_node)
 
+    def resizeEvent(self, event):
+        widgetSize = event.size()
+
+        # required to keep the engine analysis lines from growing to take up
+        # the entire area. would love a better way to do this though
+        self.sq_board_widget.setMinimumSize(0, widgetSize.height() * 0.5)
     

--- a/src/analysis_page.py
+++ b/src/analysis_page.py
@@ -50,6 +50,10 @@ class AnalysisPage(QWidget):
         layout.setColumnStretch(0,1)
         layout.setColumnStretch(1,2)
 
+        # minimum size of board widget is 1/2 window height
+        # so that might affect any "rowStretch" settings you put here
+        # in unexpected ways
+
         self.setLayout(layout)
 
     def _on_move_made(self, _):

--- a/src/engine_evaluation.py
+++ b/src/engine_evaluation.py
@@ -2,7 +2,7 @@ import threading
 import asyncio
 import concurrent
 
-from PySide2.QtWidgets import QWidget, QLabel, QGridLayout
+from PySide2.QtWidgets import QWidget, QLabel, QGridLayout, QScrollArea
 from PySide2.QtCore import Signal, Slot
 from chess import engine
 import chess
@@ -39,7 +39,8 @@ class EngineEvaluationWidget(QWidget):
             self.layout.addWidget(self.score[index], index, 0)
             self.layout.addWidget(self.variation[index], index, 1)
 
-        #self.layout.setColumnStretch(1,1) # give more room to the lines than the scores
+        # set size policy
+        self.layout.setColumnStretch(1,1) # give more room to the lines than the scores
 
         self.setLayout(self.layout)
 
@@ -70,17 +71,14 @@ class EngineEvaluationWidget(QWidget):
         board = game_node.board()
         # wait on event which sets the position to be analyzed
         with await self.engine.analysis(board, multipv=3) as analysis:
-            curr_pv_len = [0] * EngineEvaluationWidget.variation_count
             async for info in analysis:
                 relative_score = info.get("score")
                 pv = info.get("pv")
                 multipv = info.get("multipv") # 1 indexed based, NOT 0
 
                 if (relative_score is not None and 
-                    pv is not None and
-                    len(pv) >= curr_pv_len[multipv-1]):
+                    pv is not None):
 
-                    curr_pv_len[multipv-1] = len(pv)
                     self.evaluation.emit(game_node, relative_score, pv, multipv)
         
     @Slot(chess.pgn.ChildNode, engine.PovScore, list, int)

--- a/src/engine_evaluation.py
+++ b/src/engine_evaluation.py
@@ -2,7 +2,7 @@ import threading
 import asyncio
 import concurrent
 
-from PySide2.QtWidgets import QWidget, QLabel, QGridLayout, QScrollArea
+from PySide2.QtWidgets import QWidget, QLabel, QGridLayout, QScrollArea, QSizePolicy
 from PySide2.QtCore import Signal, Slot
 from chess import engine
 import chess
@@ -30,12 +30,10 @@ class EngineEvaluationWidget(QWidget):
 
         self.layout = QGridLayout()
 
-        self.score = [0] * EngineEvaluationWidget.variation_count
-        self.variation = [LineWidget()] * EngineEvaluationWidget.variation_count
-        for index in range(EngineEvaluationWidget.variation_count):
-            self.score[index] = QLabel("0")
-            self.variation[index] = LineWidget()
+        self.score = [QLabel("0") for x in range(EngineEvaluationWidget.variation_count)]
+        self.variation = [LineWidget() for x in range(EngineEvaluationWidget.variation_count)]
 
+        for index in range(EngineEvaluationWidget.variation_count):
             self.layout.addWidget(self.score[index], index, 0)
             self.layout.addWidget(self.variation[index], index, 1)
 

--- a/src/square_board.py
+++ b/src/square_board.py
@@ -13,8 +13,6 @@ class SquareBoardWidget(QWidget):
 
         # resize it to be square and centered within its parent widget
         # this needs to happen before setting the board pixmap
-        board.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed)
-
         boardGeo = self._boardGeo(self.rect().width(), self.rect().height())
         board.setGeometry(boardGeo)
 


### PR DESCRIPTION
- shift left column of analysis page to only use 1/3 of screen
- set square board to use a minimum of 1/2 the height of the screen to prevent the engine evaluation widget from squishing it
- put engine evaluation in a scroll area